### PR TITLE
Bugfix point after surface

### DIFF
--- a/gmsh_utils/gmsh_IO.py
+++ b/gmsh_utils/gmsh_IO.py
@@ -895,21 +895,16 @@ class GmshIO:
 
         # intersect all entities with each other
         entities = gmsh.model.get_entities()
-        _, new_entities_map = gmsh.model.occ.intersect(entities, entities)
+        new_entities, new_entities_map = gmsh.model.occ.intersect(entities, entities)
 
-        # get all entities with a dimension higher than 0
-        filtered_entities = [dimtag for dimtag in entities if dimtag[0] > 0]
-
-        # get all entities with a dimension higher than 0
+        # get all new entities
         filtered_entities_map = new_entities_map[:len(entities)]
-        filtered_entities_map = [dimtag for dimtag in filtered_entities_map if dimtag[0][0] > 0]
 
-        # get all physical groups with a dimension higher than 0
+        # get all physical groups
         physical_groups = gmsh.model.getPhysicalGroups()
-        filtered_physical_groups = [dimtag for dimtag in physical_groups if dimtag[0] > 0]
 
         # loop over the filtered physical groups
-        for group_dim, group_id in filtered_physical_groups:
+        for group_dim, group_id in physical_groups:
 
             # get name of the group
             name = gmsh.model.getPhysicalName(group_dim, group_id)
@@ -918,7 +913,7 @@ class GmshIO:
             entities_group = gmsh.model.getEntitiesForPhysicalGroup(group_dim, group_id)
 
             # get indices within the filtered entities array of the entities which belong to the group
-            indices = [filtered_entities.index((group_dim, entity_id)) for entity_id in entities_group]
+            indices = [entities.index((group_dim, entity_id)) for entity_id in entities_group]
 
             # get new entities which belong to the group
             new_entities_group = [filtered_entities_map[index] for index in indices]
@@ -990,6 +985,7 @@ class GmshIO:
         """
 
         self.__mesh_data = {}
+
 
 if __name__ == '__main__':
 

--- a/tests/test_gmsh_IO.py
+++ b/tests/test_gmsh_IO.py
@@ -1337,19 +1337,16 @@ class TestGmshIO:
         gmsh_io = GmshIO()
 
         # create surface input
-        input_surface = {'surface': {
-                                                "coordinates": [(0, 0, 0), (3, 0, 0), (3, 1, 0), (0, 1, 0)],
-                                                "ndim": 2}}
+        input_surface = {'surface': {"coordinates": [(0, 0, 0), (3, 0, 0), (3, 1, 0), (0, 1, 0)],
+                                     "ndim": 2}}
 
         # create point input
-        input_point = {'point': {
-                                                "coordinates": [(0, 0, 0)],
-                                                "ndim": 0}}
+        input_point = {'point': {"coordinates": [(0, 0, 0)],
+                                 "ndim": 0}}
 
         # generate point after surface
         gmsh_io.generate_geometry(input_surface, "")
         gmsh_io.generate_geometry(input_point, "")
-
 
         output_group_names = list(gmsh_io.geo_data["physical_groups"].keys())
         expected_group_names = ['surface', 'point']

--- a/tests/test_gmsh_IO.py
+++ b/tests/test_gmsh_IO.py
@@ -1355,3 +1355,72 @@ class TestGmshIO:
         for group_name in expected_group_names:
             assert group_name in output_group_names
 
+        assert gmsh_io.geo_data["physical_groups"]["surface"]["geometry_ids"] == [1]
+        assert gmsh_io.geo_data["physical_groups"]["point"]["geometry_ids"] == [1]
+
+    def test_add_multiple_points_at_surface_points(self):
+        """
+        Checks whether multiple points are added at the surface points correctly. Both the physical groups of the
+        surface and the points should be maintained.
+        """
+
+        gmsh_io = GmshIO()
+
+        # create surface input
+        input_surface = {'surface': {"coordinates": [(0, 0, 0), (3, 0, 0), (3, 1, 0), (0, 1, 0)],
+                                     "ndim": 2}}
+
+        # create point input
+        input_point = {'point': {"coordinates": [(3, 1, 0), (0, 1, 0)],
+                                 "ndim": 0}}
+
+        # generate point after surface
+        gmsh_io.generate_geometry(input_surface, "")
+        gmsh_io.generate_geometry(input_point, "")
+
+        output_group_names = list(gmsh_io.geo_data["physical_groups"].keys())
+        expected_group_names = ['surface', 'point']
+
+        # check if all groups are added
+        for group_name in expected_group_names:
+            assert group_name in output_group_names
+
+        assert gmsh_io.geo_data["physical_groups"]["surface"]["geometry_ids"] == [1]
+        assert gmsh_io.geo_data["physical_groups"]["point"]["geometry_ids"] == [3, 4]
+
+    def test_add_multiple_point_groups_to_surface_point(self):
+        """
+        Checks whether multiple points each in a different group added at the surface same points correctly.
+        All the physical groups of the surface and the points should be maintained.
+
+        """
+
+        gmsh_io = GmshIO()
+
+        # create surface input
+        input_surface = {'surface': {"coordinates": [(0, 0, 0), (3, 0, 0), (3, 1, 0), (0, 1, 0)],
+                                     "ndim": 2}}
+
+        # create point input
+        input_point = {'point1': {"coordinates": [(3, 1, 0)],
+                                  "ndim": 0}}
+
+        # create point input
+        input_point2 = {'point2': {"coordinates": [(3, 1, 0)],
+                                   "ndim": 0}}
+
+        # generate point after surface
+        gmsh_io.generate_geometry(input_surface, "")
+        gmsh_io.generate_geometry(input_point, "")
+        gmsh_io.generate_geometry(input_point2, "")
+
+        output_group_names = list(gmsh_io.geo_data["physical_groups"].keys())
+        expected_group_names = ['surface', 'point1','point2']
+
+        # check if all groups are added
+        for group_name in expected_group_names:
+            assert group_name in output_group_names
+
+        assert gmsh_io.geo_data["physical_groups"]["surface"]["geometry_ids"] == [1]
+        assert gmsh_io.geo_data["physical_groups"]["point1"]["geometry_ids"] == [3]
+        assert gmsh_io.geo_data["physical_groups"]["point2"]["geometry_ids"] == [3]

--- a/tests/test_gmsh_IO.py
+++ b/tests/test_gmsh_IO.py
@@ -1327,3 +1327,34 @@ class TestGmshIO:
 
         # check if physical groups are added correctly
         TestUtils.assert_dictionary_almost_equal(geo_data["physical_groups"], expected_group_data)
+
+    def test_add_point_at_surface_point(self):
+        """
+        Checks whether a point is added at the surface point correctly. Both the physical groups of the surface and the
+        point should be maintained.
+        """
+
+        gmsh_io = GmshIO()
+
+        # create surface input
+        input_surface = {'surface': {
+                                                "coordinates": [(0, 0, 0), (3, 0, 0), (3, 1, 0), (0, 1, 0)],
+                                                "ndim": 2}}
+
+        # create point input
+        input_point = {'point': {
+                                                "coordinates": [(0, 0, 0)],
+                                                "ndim": 0}}
+
+        # generate point after surface
+        gmsh_io.generate_geometry(input_surface, "")
+        gmsh_io.generate_geometry(input_point, "")
+
+
+        output_group_names = list(gmsh_io.geo_data["physical_groups"].keys())
+        expected_group_names = ['surface', 'point']
+
+        # check if all groups are added
+        for group_name in expected_group_names:
+            assert group_name in output_group_names
+


### PR DESCRIPTION
if point in a point physical group coincides with a surface point, the physical group of the point was removed.

this is fixed now